### PR TITLE
feat(preprocessor): update build script to support preprocessor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,20 +15,22 @@ SHELL ["/bin/bash", "-l", "-c"]
 # Initialize emcc
 RUN emcc
 
+# Setup output path
+RUN mkdir -p /out/wasm && mkdir /out/js && mkdir /out/html
+
 # Clone repo, copy build script from host, set workdir
 RUN git clone https://github.com/kwonoj/hunspell
-COPY build.sh /hunspell
+COPY build.sh preprocessor.js /hunspell/
 WORKDIR /hunspell
 
 # Checkout custom branch's sha to build, injected when build time
 RUN git checkout $BUILD_SHA && echo building commit ${BUILD_SHA}
 RUN git show --summary
-RUN mkdir -p /out/wasm && mkdir /out/js && mkdir /out/html
 
 # Configure & make via emscripten
 RUN autoreconf -vfi && emconfigure ./configure && emmake make
 
 # Build for each target, WASM / JS / HTML (HTML is for testing)
-CMD ./build.sh -s WASM=1 -o /out/wasm/hunspell.js && \
+CMD ./build.sh -o /out/wasm/hunspell.js -s WASM=1 && \
   ./build.sh -o /out/js/hunspell.js && \
   ./build.sh -o /out/html/hunspell.html

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,17 @@
-# invokce emscripten to build binary targets configured via dockerfile.
+# it is important call in forms of ./build.sh -o outputfilePath ...resg
+outputFilename=$(basename $2)
 
+# injecting -o option's filename.wasm into preprocessor
+sed -i -e "s/___wasm_binary_name___/${outputFilename%.*}.wasm/g" ./preprocessor.js
+
+# invokce emscripten to build binary targets configured via dockerfile.
 em++ \
 -O3 \
 -Oz \
 --llvm-lto 1 \
+--closure 1 \
 -s NO_EXIT_RUNTIME=1 \
--s EXPORTED_FUNCTIONS="['_Hunspell_create', '_Hunspell_destroy', '_Hunspell_spell']" \
+-s EXPORTED_FUNCTIONS="['_Hunspell_create', '_Hunspell_destroy', '_Hunspell_spell', '_Hunspell_suggest']" \
 ./src/hunspell/.libs/libhunspell-1.6.a \
+--pre-js ./preprocessor.js \
 $@

--- a/preprocessor.js
+++ b/preprocessor.js
@@ -1,0 +1,15 @@
+/**
+ * Preprocessor script to be injected into compiled output
+ *
+ * In here, detect environment and if it's node, override `Module.wasmBinaryFile`
+ * to use relative path - by default, it always look for current running directory.
+ * https://github.com/kripken/emscripten/pull/5296 will allow embed everything into
+ * single file, which'll be solution for this.
+ */
+if (typeof module !== 'undefined' && module.exports) {
+  var Module = {};
+  if (typeof __dirname === "string") {
+    //___wasm_binary_name___ is being replaced build time via build.sh
+    Module["wasmBinaryFile"] = require('path').join(__dirname, "___wasm_binary_name___");
+  }
+}


### PR DESCRIPTION
Emscripten generated module loader will try to load wasm binary from current directory always. This PR overrides `Module.wasmBinaryFile` behavior by injecting preprocessor for node.js to use relative path 
https://github.com/kripken/emscripten/pull/5296 will allow embed everything into single file, which'll be solution for this.