### PR TITLE
fix(cwrap): export cwrap function

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,7 @@ em++ \
   '_Hunspell_add_with_affix', \
   '_Hunspell_remove' \
 ]" \
+-s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap']" \
 ./src/hunspell/.libs/libhunspell-1.6.a \
 --pre-js ./preprocessor.js \
 $@


### PR DESCRIPTION
latest emscripten does not export cwrap by default.

(https://kripken.github.io/emscripten-site/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#calling-compiled-c-functions-from-javascript-using-ccall-cwrap)